### PR TITLE
Update Dutch specs to include the 2017.1 standard

### DIFF
--- a/dutch/README.md
+++ b/dutch/README.md
@@ -6,6 +6,7 @@
   language area, applicable as of 19 April 2018
 - _by_: [Braille Autoriteit](http://braille-autoriteit.org/)
 - _applies to_: The Netherlands and Flanders (as of September 2005)
+- _version_: 2017.1
 - _published_: 2018
 - _language_: Dutch
 
@@ -18,5 +19,6 @@
 - _by_: Federatie Slechtzienden- en Blindenbelang and
   Belgische Confederatie voor Blinden en Slechtzienden (BCBS)
 - _applies to_: The Netherlands and Flanders (as of September 2005)
+- _version_: 2005
 - _published_: 2005
 - _language_: Dutch

--- a/dutch/README.md
+++ b/dutch/README.md
@@ -1,6 +1,17 @@
 # Braille Specifications and Guidelines for Belgium and the Netherlands
 
-## [Braillestandaard voor algemeen gebruik in het Nederlandse taalgebied, van toepassing vanaf 1 september 2005](Eindtekst-zonder-voorblad-dec-2005.doc)
+## [Braillestandaard voor algemeen gebruik in het Nederlandse taalgebied, van toepassing vanaf 19 april 2018](http://braille-autoriteit.org/algemeen-gebruik/versie-2017-van-zespunts-standaard/)
+
+- _title translated_: Braille standard for general use in the Dutch
+  language area, applicable as of 19 April 2018
+- _by_: [Braille Autoriteit](http://braille-autoriteit.org/)
+- _applies to_: The Netherlands and Flanders (as of September 2005)
+- _published_: 2018
+- _language_: Dutch
+
+## Previous Standards
+
+### [Braillestandaard voor algemeen gebruik in het Nederlandse taalgebied, van toepassing vanaf 1 september 2005](Eindtekst-zonder-voorblad-dec-2005.doc)
 
 - _title translated_: Braille standard for general use in the Dutch
   language area, applicable as of 1 September 2005


### PR DESCRIPTION
Maybe we need to make clear that, even though this standard was published in 2018, it is referred to as version 2017.1.