### PR TITLE
Update Dutch page

### DIFF
--- a/dutch/README.md
+++ b/dutch/README.md
@@ -55,3 +55,7 @@ The most up to date versions of these standards can be found at https://braille-
 - _language_: Dutch
 
 [.doc version](Eindtekst-zonder-voorblad-dec-2005.doc)
+
+## Other Materials
+
+Various other documentation, such as historical documents, documents about Dutch contracted braille (which is not taught anymore), and documents about math braille, can be found at https://braille-autoriteit.org/wijzigingsverzoeken/historisch-materiaal.

--- a/dutch/README.md
+++ b/dutch/README.md
@@ -1,15 +1,25 @@
 # Braille Specifications and Guidelines for Belgium and the Netherlands
 
-## [Braillestandaard voor algemeen gebruik in het Nederlandse taalgebied, versie 2017](http://braille-autoriteit.org/algemeen-gebruik/versie-2017-van-zespunts-standaard/)
+The most up to date versions of these standards can be found at https://braille-autoriteit.org/standaarden/.
+
+## [Braillestandaard voor algemeen gebruik in het Nederlandse taalgebied, versie 2019](https://braille-autoriteit.org/versie-2019-van-zespunts-standaard/)
 
 - _title translated_: Braille standard for general use in the Dutch
-  language area, version 2017
+  language area, version 2019
 - _by_: [Braille Autoriteit](http://braille-autoriteit.org/)
-- _applies to_: The Netherlands and Flanders (as of April 19th, 2018)
-- _version_: 2017.1
-- _published_: 2018
+- _applies to_: The Netherlands and Flanders (as of April 24th, 2020)
+- _version_: 2019
+- _published_: 2020-04-24
 - _language_: Dutch
 
+## [Achtpunts braillestandaard voor het Nederlandse taalgebied, versie 2020](https://braille-autoriteit.org/standaarden/achtpuntsbraille/versie-2020/)
+
+- _title translated_: 8-dot braille standard for the Dutch language area, version 2020
+- _by_: [Braille Autoriteit](http://braille-autoriteit.org/)
+- _applies to_: The Netherlands and Flanders (as of December 31th, 2020)
+- _version_: 2020
+- _published_: 2020-10-28
+- _language_: Dutch
 
 ## [Handleiding Braillesymbolen Wiskunde](Handleiding%20braillesymbolen%20wiskunde.pdf) (beter bekend als de "Woluwecode" of de "Notaertcode")
 
@@ -21,7 +31,19 @@
 
 ## Previous Standards
 
-### [Braillestandaard voor algemeen gebruik in het Nederlandse taalgebied, versie 2005](Eindtekst-zonder-voorblad-dec-2005.doc)
+### Braillestandaard voor algemeen gebruik in het Nederlandse taalgebied
+
+### [versie 2017](http://braille-autoriteit.org/algemeen-gebruik/versie-2017-van-zespunts-standaard/)
+
+- _title translated_: Braille standard for general use in the Dutch
+  language area, version 2017
+- _by_: [Braille Autoriteit](http://braille-autoriteit.org/)
+- _applies to_: The Netherlands and Flanders (as of April 19th, 2018)
+- _version_: 2017
+- _published_: 2018
+- _language_: Dutch
+
+### [versie 2005](http://braille-autoriteit.org/algemeen-gebruik/versie-2017-van-zespunts-standaard)
 
 - _title translated_: Braille standard for general use in the Dutch
   language area, version 2005
@@ -32,4 +54,4 @@
 - _published_: 2005
 - _language_: Dutch
 
-[HTML version](http://braille-autoriteit.org/algemeen-gebruik/versie-2017-van-zespunts-standaard)
+[.doc version](Eindtekst-zonder-voorblad-dec-2005.doc)


### PR DESCRIPTION
- "Braillestandaard voor algemeen gebruik in het Nederlandse taalgebied" is now at version 2019
- New standard "Achtpunts braillestandaard voor het Nederlandse taalgebied"