### PR TITLE
Add Persian Braille source provenance

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ Note that, despite the title, this is **not** the ISO standard itself, which has
 
 ## [Norwegian](norwegian/README.md)
 
+## [Persian](persian/README.md)
+
 ## [Polish](polish/README.md)
 
 ## [Russian](russian/README.md)

--- a/norwegian/README.md
+++ b/norwegian/README.md
@@ -3,7 +3,7 @@ Norwegian Braille Specifications and Guidelines
 
 ## [Punkttabell for JAWS](2019%20-%20Punkttabell%20for%20JAWS.jbt)
 
- * _Title translated_: Braille table for JAWS
+ * _title translated_: Braille table for JAWS
  * _by_: [Offentlig utvalg for blindeskrift](http://www.punktskriftutvalget.no/)
  * _published_: 2019
  * _language_: Norwegian
@@ -13,14 +13,14 @@ It maps characters to 8-dot braille.
 
 ## [To eller flere ord med store bokstaver](2018%20-%20To%20eller%20flere%20ord%20med%20store%20bokstaver.pdf)
 
- * _Title translated_: Two or more words with capitalized letters
+ * _title translated_: Two or more words with capitalized letters
  * _by_: [Offentlig utvalg for punktskrift](http://www.punktskriftutvalget.no/)
  * _published_: Oslo, 2018
  * _language_: Norwegian
 
 ## [Håndbok i litterær punktskrift](2012%20-%20Håndbok%20i%20litterær%20punktskrift.pdf)
 
- * _Title translated_: Handbook in literary braille
+ * _title translated_: Handbook in literary braille
  * _by_: [Offentlig utvalg for punktskrift](http://www.punktskriftutvalget.no/)
  * _published_: Oslo, 2012
  * _language_: Norwegian
@@ -32,7 +32,7 @@ It maps characters to 8-dot braille.
 
 ## [Punkttabell for JAWS](2011%20-%20Punkttabell%20for%20JAWS.jbt)
 
- * _Title translated_: Braille table for JAWS
+ * _title translated_: Braille table for JAWS
  * _by_: [Offentlig utvalg for blindeskrift](http://www.punktskriftutvalget.no/)
  * _published_: 2011
  * _language_: Norwegian
@@ -42,7 +42,7 @@ It maps characters to 8-dot braille.
 
 ## [Matematikk med leselist](2010%20-%20Matematikk%20med%20leselist.pdf)
 
- * _Title translated_: Math on a braille display
+ * _title translated_: Math on a braille display
  * _by_: [Huseby og Tambartun kompetansesentre](http://www.statped.no/Spraksider/In-English/)
  * _published_: 2010
  * _language_: Norwegian
@@ -53,7 +53,7 @@ It maps characters to 8-dot braille.
 
 ## [Kortskrift i norsk punktskrift - KS04](2008%20-%20Kortskrift%20i%20norsk%20punktskrift%20-%20KS04.doc)
 
- * _Title translated_: Norwegian Contracted Braille - KS04
+ * _title translated_: Norwegian Contracted Braille - KS04
  * _by_: [Offentlig utvalg for blindeskrift](http://www.punktskriftutvalget.no/)
  * _published_: 2008
  * _language_: Norwegian
@@ -63,7 +63,7 @@ It maps characters to 8-dot braille.
 
 ## [8-punktstabell](2007%20-%208-punktstabell.docx)
 
- * _Title translated_: 8-dot braille table
+ * _title translated_: 8-dot braille table
  * _by_: [Offentlig utvalg for blindeskrift](http://www.punktskriftutvalget.no/)
  * _published_: 2007
  * _language_: Norwegian
@@ -75,7 +75,7 @@ There's no headlines.
 
 ## [Norsk Punktskrift - del 4](1995%20-%20Norsk%20Punktskrift%20-%20del%204.pdf)
 
- * _Title translated_: Norwegian Braille - part 4
+ * _title translated_: Norwegian Braille - part 4
  * _by_: [Huseby kompetansesenter - Statlig spesialpedagogisk senter for synshemmede](http://www.statped.no/Spraksider/In-English/)
  * _published_: Oslo, 1995
  * _language_: Norwegian

--- a/persian/README.md
+++ b/persian/README.md
@@ -1,0 +1,112 @@
+# Persian (Iran)
+
+This page records provenance and page references for a historical Iranian
+institutional source. It does not reproduce the source or its Braille tables.
+
+## 2014 institutional manual
+
+- _title_: مجموعه علائم بریل
+- _descriptive English title_: Collection of Braille Signs
+- _issued by_: Iran's National Organization for Special Education
+  (سازمان آموزش و پرورش استثنایی کشور)
+- _responsible unit_: Deputy for Educational Planning and Rehabilitation
+  (معاونت برنامه‌ریزی آموزشی و توان‌بخشی)
+- _published_: Iran, 1393 SH / 2014 CE
+- _language_: Persian, with sections covering other languages and notations
+- _extent_: 371 PDF pages: an unnumbered cover followed by printed pages 1–370
+- _status_: official-institutional historical source; current normative status
+  unverified
+
+### Provenance
+
+The title appears in an [archived 2014 catalog of Iran's Ministry of
+Education](https://web.archive.org/web/20140828055145/http://www.medu.ir/portal/Home/ShowPage.aspx?Object=DirectoryView%26CategoryID=5e202802-bad0-431b-b0d7-5b9dc4967a3b%26LayoutID=ea1a5bb4-1ae7-4077-8d7c-da52e62d0808%26DirectoryID=b55838a1-24b3-4ab0-af00-b2a5fb2fbb00%26ID=474d0152-09bf-4108-9197-f80752900987)
+under material for visually impaired students. The catalog object UUID is
+`70a072ca-f083-45ad-a1ff-95614de30bc5`.
+
+Two contemporaneous pages provide additional provenance:
+
+- a [14 Tir 1393 announcement](https://7mhr.blogfa.com/post/101) pointing
+  readers to the Ministry catalog; and
+- an [educator's reference page](https://blindsteacher.blogfa.com/post/34)
+  linking both the Ministry listing and a public mirror.
+
+A [surviving mirror landing
+page](https://s4.picofile.com/file/8171401192/alaem_brill.rar.html) provides the
+archive from which the fingerprints below were calculated. The former official
+download binary was not recovered, so the mirror has not been proven
+byte-identical to it.
+
+### Artifact fingerprints
+
+These fingerprints identify the recovered mirror artifacts. Neither artifact
+is stored in this repository.
+
+| Artifact | Size | SHA-256 |
+| --- | ---: | --- |
+| `alaem_brill.rar` | 4,174,566 bytes | `12a2179180ba0375e77a517a86fffd2f5c1326f9917608a76a8c40cd5db222cb` |
+| `alaem brill.pdf` | 9,697,432 bytes | `7974b08c12ece7242b2a435e71c5c8cacc2f296bad8728544a310cb33c9ada63` |
+
+The PDF member has RAR CRC-32 `526DF072`.
+
+### Page map
+
+The cover is PDF page 1 and has no printed page number. For the remainder of
+this file, the PDF page number is the printed page number plus one.
+
+| Subject | Printed pages | PDF pages |
+| --- | ---: | ---: |
+| Introduction and methodology | 12–18 | 13–19 |
+| General material and history | 19–30 | 20–31 |
+| Persian literary Braille | 31–95 | 32–96 |
+| Persian alphabet | 32–33 | 33–34 |
+| Persian punctuation and arithmetic signs | 34–40 | 35–41 |
+| Persian document and transcription conventions | 41–48 | 42–49 |
+| Persian orthography | 49–67 | 50–68 |
+| Persian short forms | 68–89 | 69–90 |
+| Persian phonetics | 90–95 | 91–96 |
+| Arabic and Quranic material | 96–100 | 97–101 |
+| English | 101–135 | 102–136 |
+| English Grade 1 | 102–103 | 103–104 |
+| English Grade 2 | 104–120 | 105–121 |
+| English phonetics and umlauts | 121–135 | 122–136 |
+| Mathematics and sciences | 136–206 | 137–207 |
+| Computer Braille section divider | 207 | 208 |
+| Computer Braille introduction | 208–209 | 209–210 |
+| American Computer Braille | 210–213 | 211–214 |
+| British Computer Braille | 214–217 | 215–218 |
+| Music | 218–290 | 219–291 |
+| Iranian music | 277–284 | 278–285 |
+| Appendices | 291–363 | 292–364 |
+| Sources | 364–370 | 365–371 |
+
+The computer section describes American and British ASCII-era Computer
+Braille. It is not an explicit Persian eight-dot Unicode code. The manual also
+predates an explicit model for Unicode normalization, ZWNJ, bidirectional text,
+cursor routing, and translation round trips. These behaviors require separate,
+modern specification and validation.
+
+The PDF uses embedded Braille fonts without usable Unicode mappings, and its
+Persian text extraction is affected by bidirectional ordering. Any future
+machine-readable transcription should therefore be independently transcribed
+twice and checked against rendered pages.
+
+## Nonclaims and reuse status
+
+- This page does not claim that the 2014 manual is Iran's current standard or
+  that no later edition exists.
+- “Persian Braille 2026” is a project label, not a national standard or an
+  endorsement by the issuing organization.
+- No 2026 approval by an Iranian authority or validation by native blind
+  Persian Braille readers is claimed.
+- The mirror's relationship to the former official binary is supported by
+  historical links but not by matching cryptographic fingerprints.
+- No redistribution license was found. The PDF, RAR, page images, embedded
+  fonts, OCR text, and manual content are intentionally not included here.
+- The links, hashes, metadata, and page map document provenance; they do not
+  grant permission to reproduce the source.
+- This page is not a transcription of the manual and does not define a Persian
+  literary or computer-Braille translation table.
+
+The corresponding implementation audit and open policy questions are tracked
+in [liblouis/liblouis#2053](https://github.com/liblouis/liblouis/issues/2053).

--- a/persian/README.md
+++ b/persian/README.md
@@ -1,23 +1,29 @@
 # Persian (Iran)
 
-This page records provenance and page references for a historical Iranian
-institutional source. It does not reproduce the source or its Braille tables.
+This page records provenance and page references for a historical
+Iranian institutional source.
 
-## 2014 institutional manual
+This page does not claim that the 2014 manual is Iran's current
+standard or that no later edition exists.
 
-- _title_: مجموعه علائم بریل
-- _descriptive English title_: Collection of Braille Signs
-- _issued by_: Iran's National Organization for Special Education
-  (سازمان آموزش و پرورش استثنایی کشور)
-- _responsible unit_: Deputy for Educational Planning and Rehabilitation
-  (معاونت برنامه‌ریزی آموزشی و توان‌بخشی)
-- _published_: Iran, 1393 SH / 2014 CE
-- _language_: Persian, with sections covering other languages and notations
-- _extent_: 371 PDF pages: an unnumbered cover followed by printed pages 1–370
-- _status_: official-institutional historical source; current normative status
-  unverified
+## مجموعه علائم بریل
+
+- _title translated_: Collection of Braille Signs
+- _by_: Iran's National Organization for Special Education (سازمان آموزش و پرورش استثنایی کشور)
+- _applies to_: Iran
+- _published_: Deputy for Educational Planning and Rehabilitation (معاونت برنامه‌ریزی آموزشی و توان‌بخشی), Iran, 2014 (1393 SH)
+- _language_: Persian
+
+This is an official-institutional historical source. The current
+normative status of the document is unverified. No 2026 approval by an
+Iranian authority or validation by native blind Persian braille
+readers is claimed.
 
 ### Provenance
+
+The document, or its OCR text, is intentionally not included here
+because no redistribution license was found. This page documents
+provenance and does not grant permission to reproduce the source.
 
 The title appears in an [archived 2014 catalog of Iran's Ministry of
 Education](https://web.archive.org/web/20140828055145/http://www.medu.ir/portal/Home/ShowPage.aspx?Object=DirectoryView%26CategoryID=5e202802-bad0-431b-b0d7-5b9dc4967a3b%26LayoutID=ea1a5bb4-1ae7-4077-8d7c-da52e62d0808%26DirectoryID=b55838a1-24b3-4ab0-af00-b2a5fb2fbb00%26ID=474d0152-09bf-4108-9197-f80752900987)
@@ -37,8 +43,6 @@ archive from which the fingerprints below were calculated. The former official
 download binary was not recovered, so the mirror has not been proven
 byte-identical to it.
 
-### Artifact fingerprints
-
 These fingerprints identify the recovered mirror artifacts. Neither artifact
 is stored in this repository.
 
@@ -49,16 +53,18 @@ is stored in this repository.
 
 The PDF member has RAR CRC-32 `526DF072`.
 
-### Page map
+### (Translated) table of contents
 
-The cover is PDF page 1 and has no printed page number. For the remainder of
-this file, the PDF page number is the printed page number plus one.
+The PDF has 371 pages: an unnumbered cover followed by printed pages
+1–370. The cover is PDF page 1 and has no printed page number. For the
+remainder of this file, the PDF page number is the printed page number
+plus one.
 
 | Subject | Printed pages | PDF pages |
 | --- | ---: | ---: |
 | Introduction and methodology | 12–18 | 13–19 |
 | General material and history | 19–30 | 20–31 |
-| Persian literary Braille | 31–95 | 32–96 |
+| Persian literary braille | 31–95 | 32–96 |
 | Persian alphabet | 32–33 | 33–34 |
 | Persian punctuation and arithmetic signs | 34–40 | 35–41 |
 | Persian document and transcription conventions | 41–48 | 42–49 |
@@ -67,46 +73,23 @@ this file, the PDF page number is the printed page number plus one.
 | Persian phonetics | 90–95 | 91–96 |
 | Arabic and Quranic material | 96–100 | 97–101 |
 | English | 101–135 | 102–136 |
-| English Grade 1 | 102–103 | 103–104 |
-| English Grade 2 | 104–120 | 105–121 |
+| English grade 1 | 102–103 | 103–104 |
+| English grade 2 | 104–120 | 105–121 |
 | English phonetics and umlauts | 121–135 | 122–136 |
 | Mathematics and sciences | 136–206 | 137–207 |
-| Computer Braille section divider | 207 | 208 |
-| Computer Braille introduction | 208–209 | 209–210 |
-| American Computer Braille | 210–213 | 211–214 |
-| British Computer Braille | 214–217 | 215–218 |
+| Computer braille section divider | 207 | 208 |
+| Computer braille introduction | 208–209 | 209–210 |
+| American computer braille | 210–213 | 211–214 |
+| British computer braille | 214–217 | 215–218 |
 | Music | 218–290 | 219–291 |
 | Iranian music | 277–284 | 278–285 |
 | Appendices | 291–363 | 292–364 |
 | Sources | 364–370 | 365–371 |
 
-The computer section describes American and British ASCII-era Computer
-Braille. It is not an explicit Persian eight-dot Unicode code. The manual also
+### Notes
+
+The computer section describes American and British ASCII-era computer
+braille. It is not an explicit Persian eight-dot Unicode code. The manual also
 predates an explicit model for Unicode normalization, ZWNJ, bidirectional text,
 cursor routing, and translation round trips. These behaviors require separate,
 modern specification and validation.
-
-The PDF uses embedded Braille fonts without usable Unicode mappings, and its
-Persian text extraction is affected by bidirectional ordering. Any future
-machine-readable transcription should therefore be independently transcribed
-twice and checked against rendered pages.
-
-## Nonclaims and reuse status
-
-- This page does not claim that the 2014 manual is Iran's current standard or
-  that no later edition exists.
-- “Persian Braille 2026” is a project label, not a national standard or an
-  endorsement by the issuing organization.
-- No 2026 approval by an Iranian authority or validation by native blind
-  Persian Braille readers is claimed.
-- The mirror's relationship to the former official binary is supported by
-  historical links but not by matching cryptographic fingerprints.
-- No redistribution license was found. The PDF, RAR, page images, embedded
-  fonts, OCR text, and manual content are intentionally not included here.
-- The links, hashes, metadata, and page map document provenance; they do not
-  grant permission to reproduce the source.
-- This page is not a transcription of the manual and does not define a Persian
-  literary or computer-Braille translation table.
-
-The corresponding implementation audit and open policy questions are tracked
-in [liblouis/liblouis#2053](https://github.com/liblouis/liblouis/issues/2053).

--- a/persian/README.md
+++ b/persian/README.md
@@ -14,16 +14,15 @@ standard or that no later edition exists.
 - _published_: Deputy for Educational Planning and Rehabilitation (معاونت برنامه‌ریزی آموزشی و توان‌بخشی), Iran, 2014 (1393 SH)
 - _language_: Persian
 
-This is an official-institutional historical source. The current
-normative status of the document is unverified. No 2026 approval by an
-Iranian authority or validation by native blind Persian braille
-readers is claimed.
+This is an official-institutional historical source. Its current
+normative status has not been verified, and no validation by
+proficient Persian braille readers is claimed.
 
 ### Provenance
 
-The document, or its OCR text, is intentionally not included here
-because no redistribution license was found. This page documents
-provenance and does not grant permission to reproduce the source.
+The document, or its OCR text, is intentionally not included here because
+no redistribution license was found. This page documents provenance
+and does not grant permission to reproduce the source.
 
 The title appears in an [archived 2014 catalog of Iran's Ministry of
 Education](https://web.archive.org/web/20140828055145/http://www.medu.ir/portal/Home/ShowPage.aspx?Object=DirectoryView%26CategoryID=5e202802-bad0-431b-b0d7-5b9dc4967a3b%26LayoutID=ea1a5bb4-1ae7-4077-8d7c-da52e62d0808%26DirectoryID=b55838a1-24b3-4ab0-af00-b2a5fb2fbb00%26ID=474d0152-09bf-4108-9197-f80752900987)
@@ -37,14 +36,14 @@ Two contemporaneous pages provide additional provenance:
 - an [educator's reference page](https://blindsteacher.blogfa.com/post/34)
   linking both the Ministry listing and a public mirror.
 
-A [surviving mirror landing
-page](https://s4.picofile.com/file/8171401192/alaem_brill.rar.html) provides the
-archive from which the fingerprints below were calculated. The former official
-download binary was not recovered, so the mirror has not been proven
-byte-identical to it.
+The Ministry’s original download could not be recovered. The surviving
+copy comes from a [third-party
+mirror](https://s4.picofile.com/file/8171401192/alaem_brill.rar.html),
+so it cannot be verified as byte-for-byte identical to the former
+Ministry download.
 
-These fingerprints identify the recovered mirror artifacts. Neither artifact
-is stored in this repository.
+The fingerprints below identify the recovered mirror
+artifacts. Neither artifact is stored in this repository.
 
 | Artifact | Size | SHA-256 |
 | --- | ---: | --- |
@@ -52,6 +51,12 @@ is stored in this repository.
 | `alaem brill.pdf` | 9,697,432 bytes | `7974b08c12ece7242b2a435e71c5c8cacc2f296bad8728544a310cb33c9ada63` |
 
 The PDF member has RAR CRC-32 `526DF072`.
+
+Text and braille symbols extracted automatically from the PDF may be
+unreliable, as the PDF uses embedded braille fonts without usable
+Unicode mappings, and its Persian text extraction is affected by
+bidirectional ordering. The rendered pages should be treated as the
+source.
 
 ### (Translated) table of contents
 

--- a/russian/README.md
+++ b/russian/README.md
@@ -4,7 +4,7 @@
 
 - _title translated_: Guidelines for edition of mass-distribution braille publications
 - _by_: ["CHTENIE" Publishing House of All-Russia Society of the blind](http://chtenie.spb.ru)
-- _year_: 2015
+- _published_: 2015
 - _language_: Russian
 
 [Table of contents](toc.md)
@@ -13,7 +13,7 @@
 
 - _title translated_: Braille codes of the national languages of Russia
 - _by_: [The Russian State Library for the Blind](https://rgbs.ru)
-- _year_: 2017
+- _published_: 2017
 - _language_: Russian
 
 This reference book describes braille codes of the languages of the different nations that live in Russia. Most of these codes aren't supported by official documents, but blind representatives of these nations use these ones and even have braille books in their languages.


### PR DESCRIPTION
## Summary

Add the first Persian entry to the braille-specs index and document the
provenance of the historical 1393/2014 Iranian manual `مجموعه علائم بریل`.

The new page records:

- issuing institution, date, language, and extent
- archived official-catalog and contemporaneous source links
- fingerprints for the recovered mirror artifacts
- printed-page/PDF-page concordance for the relevant sections
- limitations of the legacy computer-Braille section and PDF extraction
- explicit approval, provenance, reader-validation, and reuse nonclaims

No PDF, RAR, page image, embedded font, OCR output, or copied manual table is
included because reuse rights have not been established.

## Status

This is provenance documentation, not a claim that the manual remains Iran's
current standard. “Persian Braille 2026” is a community project label, not a
national standard, and no native/proficient Persian Braille-reader validation
is claimed.

Implementation discussion is tracked in
[liblouis/liblouis#2053](https://github.com/liblouis/liblouis/issues/2053), with
the current Grade 1 proposal in draft
[liblouis/liblouis#2054](https://github.com/liblouis/liblouis/pull/2054).

## Check

`git diff --check` passes.

